### PR TITLE
Add client-side GetInventoryItems and GetInventoryImagePath

### DIFF
--- a/exports/client.lua
+++ b/exports/client.lua
@@ -25,3 +25,6 @@ exports('RemoveTargetZone', InputUtils.RemoveTargetZone)
 
 exports('GetPlayerInventory', GetPlayerInventory)
 exports('GetItemCount', GetItemCount)
+
+exports('GetInventoryItems', GetInventoryItems)
+exports('GetInventoryImagePath', GetInventoryImagePath)

--- a/exports/server.lua
+++ b/exports/server.lua
@@ -27,6 +27,14 @@ exports('GiveVehicleKeys', GiveVehicleKeys)
 exports('RemoveVehicleKeys', RemoveVehicleKeys)
 
 exports('GetPlayerInventory', GetPlayerInventory)
+
+RegisterServerCallback('kq_link:getInventoryItems', function(source, cb)
+    if type(GetInventoryItems) ~= 'function' then
+        return cb({})
+    end
+    cb(GetInventoryItems())
+end)
+
 -- RESOURCE
 exports('AddPlayerItemToFit', AddPlayerItemToFit)
 exports('RegisterServerCallback', RegisterServerCallback)

--- a/exports/server.lua
+++ b/exports/server.lua
@@ -27,14 +27,6 @@ exports('GiveVehicleKeys', GiveVehicleKeys)
 exports('RemoveVehicleKeys', RemoveVehicleKeys)
 
 exports('GetPlayerInventory', GetPlayerInventory)
-
-RegisterServerCallback('kq_link:getInventoryItems', function(source, cb)
-    if type(GetInventoryItems) ~= 'function' then
-        return cb({})
-    end
-    cb(GetInventoryItems())
-end)
-
 -- RESOURCE
 exports('AddPlayerItemToFit', AddPlayerItemToFit)
 exports('RegisterServerCallback', RegisterServerCallback)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -88,9 +88,15 @@ client_scripts {
 
 
     -- INVENTORIES
-    'links/inventories/ox_inventory/client.lua',
-    'links/inventories/qs-inventory/client.lua',
+    'links/inventories/ak47_inventory/client.lua',
+    'links/inventories/chezza/client.lua',
     'links/inventories/codem-inventory/client.lua',
+    'links/inventories/core_inventory/client.lua',
+    'links/inventories/jaksam/client.lua',
+    'links/inventories/origen_inventory/client.lua',
+    'links/inventories/ox_inventory/client.lua',
+    'links/inventories/ps-inventory/client.lua',
+    'links/inventories/qs-inventory/client.lua',
     'links/inventories/tgiann-inventory/client.lua',
 
     -- VEHICLE KEYS

--- a/links/frameworks/esx/client.lua
+++ b/links/frameworks/esx/client.lua
@@ -48,12 +48,10 @@ function NotifyViaFramework(message, type)
 end
 
 if Link.inventory == 'framework' then
-    local itemsCache
     function GetInventoryItems()
-        if itemsCache then return itemsCache end
-        local items = TriggerServerCallback('kq_link:getInventoryItems') or {}
-        if next(items) then itemsCache = items end
-        return items
+        return UseCache('kq_link:esx-framework:items', function()
+            return TriggerServerCallback('kq_link:getInventoryItems') or {}
+        end, 60000)
     end
 
     function GetInventoryImagePath()

--- a/links/frameworks/esx/client.lua
+++ b/links/frameworks/esx/client.lua
@@ -46,3 +46,17 @@ function NotifyViaFramework(message, type)
 
     ESX.ShowNotification(message, type, 4000)
 end
+
+if Link.inventory == 'framework' then
+    local itemsCache
+    function GetInventoryItems()
+        if itemsCache then return itemsCache end
+        local items = TriggerServerCallback('kq_link:getInventoryItems') or {}
+        if next(items) then itemsCache = items end
+        return items
+    end
+
+    function GetInventoryImagePath()
+        return '', 'png'
+    end
+end

--- a/links/frameworks/esx/server.lua
+++ b/links/frameworks/esx/server.lua
@@ -172,6 +172,12 @@ if Link.inventory == 'framework' then
         xPlayer.removeWeapon(weapon)
         return true
     end
+
+    function GetInventoryItems()
+        if type(ESX.GetItems) ~= 'function' then return {} end
+        local raw = ESX.GetItems()
+        return NormalizeItems(raw)
+    end
 end
 
 function GetPlayerCharacterId(player)

--- a/links/frameworks/qbcore/client.lua
+++ b/links/frameworks/qbcore/client.lua
@@ -29,15 +29,13 @@ function NotifyViaFramework(message, type)
 end
 
 if Link.inventory == 'framework' or Link.inventory == 'qb-inventory' then
-    local itemsCache
     function GetInventoryItems()
-        if itemsCache then return itemsCache end
-        if not QBCore or not QBCore.Shared or type(QBCore.Shared.Items) ~= 'table' then
-            return {}
-        end
-        local items = NormalizeItems(QBCore.Shared.Items)
-        if next(items) then itemsCache = items end
-        return items
+        return UseCache('kq_link:qb-inventory:items', function()
+            if not QBCore or not QBCore.Shared or type(QBCore.Shared.Items) ~= 'table' then
+                return {}
+            end
+            return NormalizeItems(QBCore.Shared.Items)
+        end, 60000)
     end
 
     function GetInventoryImagePath()

--- a/links/frameworks/qbcore/client.lua
+++ b/links/frameworks/qbcore/client.lua
@@ -27,3 +27,20 @@ end
 function NotifyViaFramework(message, type)
     QBCore.Functions.Notify(message, type, 4000)
 end
+
+if Link.inventory == 'framework' or Link.inventory == 'qb-inventory' then
+    local itemsCache
+    function GetInventoryItems()
+        if itemsCache then return itemsCache end
+        if not QBCore or not QBCore.Shared or type(QBCore.Shared.Items) ~= 'table' then
+            return {}
+        end
+        local items = NormalizeItems(QBCore.Shared.Items)
+        if next(items) then itemsCache = items end
+        return items
+    end
+
+    function GetInventoryImagePath()
+        return 'nui://qb-inventory/html/images/', 'png'
+    end
+end

--- a/links/frameworks/server.lua
+++ b/links/frameworks/server.lua
@@ -5,3 +5,10 @@ end)
 RegisterServerCallback('kq_link:callback:getPlayerInventory', function(player)
     return GetPlayerInventory(player)
 end)
+
+RegisterServerCallback('kq_link:getInventoryItems', function(source, cb)
+    if type(GetInventoryItems) ~= 'function' then
+        return cb({})
+    end
+    cb(GetInventoryItems())
+end)

--- a/links/frameworks/standalone/client.lua
+++ b/links/frameworks/standalone/client.lua
@@ -5,3 +5,11 @@ end
 function GetPlayerJob()
     return nil
 end
+
+function GetInventoryItems()
+    return {}
+end
+
+function GetInventoryImagePath()
+    return '', 'png'
+end

--- a/links/inventories/ak47_inventory/client.lua
+++ b/links/inventories/ak47_inventory/client.lua
@@ -12,12 +12,10 @@ function GetPlayerInventory()
     return NormalizeInventoryOutput(exports['ak47_inventory']:Items())
 end
 
-local itemsCache
 function GetInventoryItems()
-    if itemsCache then return itemsCache end
-    local items = NormalizeItems(exports['ak47_inventory']:Items())
-    if next(items) then itemsCache = items end
-    return items
+    return UseCache('kq_link:ak47_inventory:items', function()
+        return NormalizeItems(exports['ak47_inventory']:Items())
+    end, 60000)
 end
 
 function GetInventoryImagePath()

--- a/links/inventories/ak47_inventory/client.lua
+++ b/links/inventories/ak47_inventory/client.lua
@@ -11,3 +11,17 @@ end
 function GetPlayerInventory()
     return NormalizeInventoryOutput(exports['ak47_inventory']:Items())
 end
+
+local itemsCache
+function GetInventoryItems()
+    if itemsCache then return itemsCache end
+    local ok, raw = pcall(function() return exports['ak47_inventory']:Items() end)
+    if not ok then return {} end
+    local items = NormalizeItems(raw)
+    if next(items) then itemsCache = items end
+    return items
+end
+
+function GetInventoryImagePath()
+    return '', 'png'
+end

--- a/links/inventories/ak47_inventory/client.lua
+++ b/links/inventories/ak47_inventory/client.lua
@@ -15,9 +15,7 @@ end
 local itemsCache
 function GetInventoryItems()
     if itemsCache then return itemsCache end
-    local ok, raw = pcall(function() return exports['ak47_inventory']:Items() end)
-    if not ok then return {} end
-    local items = NormalizeItems(raw)
+    local items = NormalizeItems(exports['ak47_inventory']:Items())
     if next(items) then itemsCache = items end
     return items
 end

--- a/links/inventories/chezza/client.lua
+++ b/links/inventories/chezza/client.lua
@@ -10,12 +10,10 @@ function GetPlayerInventory()
     return NormalizeInventoryOutput(TriggerServerCallback('kq_link:callback:getPlayerInventory'))
 end
 
-local itemsCache
 function GetInventoryItems()
-    if itemsCache then return itemsCache end
-    local items = TriggerServerCallback('kq_link:getInventoryItems') or {}
-    if next(items) then itemsCache = items end
-    return items
+    return UseCache('kq_link:chezza:items', function()
+        return TriggerServerCallback('kq_link:getInventoryItems') or {}
+    end, 60000)
 end
 
 function GetInventoryImagePath()

--- a/links/inventories/chezza/client.lua
+++ b/links/inventories/chezza/client.lua
@@ -9,3 +9,15 @@ end
 function GetPlayerInventory()
     return NormalizeInventoryOutput(TriggerServerCallback('kq_link:callback:getPlayerInventory'))
 end
+
+local itemsCache
+function GetInventoryItems()
+    if itemsCache then return itemsCache end
+    local items = TriggerServerCallback('kq_link:getInventoryItems') or {}
+    if next(items) then itemsCache = items end
+    return items
+end
+
+function GetInventoryImagePath()
+    return 'nui://inventory/html/img/items/', 'png'
+end

--- a/links/inventories/chezza/server.lua
+++ b/links/inventories/chezza/server.lua
@@ -88,4 +88,10 @@ function RemovePlayerWeapon(player, weapon)
     xPlayer.removeWeapon(weapon)
     return true
 end
+
+function GetInventoryItems()
+    if not ESX or type(ESX.GetItems) ~= 'function' then return {} end
+    local raw = ESX.GetItems()
+    return NormalizeItems(raw)
+end
 --

--- a/links/inventories/codem-inventory/client.lua
+++ b/links/inventories/codem-inventory/client.lua
@@ -17,3 +17,17 @@ end
 function GetPlayerInventory()
     return NormalizeInventoryOutput(exports['codem-inventory']:getUserInventory())
 end
+
+local itemsCache
+function GetInventoryItems()
+    if itemsCache then return itemsCache end
+    local ok, raw = pcall(function() return exports['codem-inventory']:GetItemList() end)
+    if not ok then return {} end
+    local items = NormalizeItems(raw)
+    if next(items) then itemsCache = items end
+    return items
+end
+
+function GetInventoryImagePath()
+    return 'nui://codem-inventory/html/itemimages/', 'png'
+end

--- a/links/inventories/codem-inventory/client.lua
+++ b/links/inventories/codem-inventory/client.lua
@@ -21,9 +21,7 @@ end
 local itemsCache
 function GetInventoryItems()
     if itemsCache then return itemsCache end
-    local ok, raw = pcall(function() return exports['codem-inventory']:GetItemList() end)
-    if not ok then return {} end
-    local items = NormalizeItems(raw)
+    local items = NormalizeItems(exports['codem-inventory']:GetItemList())
     if next(items) then itemsCache = items end
     return items
 end

--- a/links/inventories/codem-inventory/client.lua
+++ b/links/inventories/codem-inventory/client.lua
@@ -18,12 +18,10 @@ function GetPlayerInventory()
     return NormalizeInventoryOutput(exports['codem-inventory']:getUserInventory())
 end
 
-local itemsCache
 function GetInventoryItems()
-    if itemsCache then return itemsCache end
-    local items = NormalizeItems(exports['codem-inventory']:GetItemList())
-    if next(items) then itemsCache = items end
-    return items
+    return UseCache('kq_link:codem-inventory:items', function()
+        return NormalizeItems(exports['codem-inventory']:GetItemList())
+    end, 60000)
 end
 
 function GetInventoryImagePath()

--- a/links/inventories/core_inventory/client.lua
+++ b/links/inventories/core_inventory/client.lua
@@ -10,12 +10,10 @@ function GetPlayerInventory()
     return NormalizeInventoryOutput(exports.core_inventory:getInventory())
 end
 
-local itemsCache
 function GetInventoryItems()
-    if itemsCache then return itemsCache end
-    local items = TriggerServerCallback('kq_link:getInventoryItems') or {}
-    if next(items) then itemsCache = items end
-    return items
+    return UseCache('kq_link:core_inventory:items:client', function()
+        return TriggerServerCallback('kq_link:getInventoryItems') or {}
+    end, 60000)
 end
 
 function GetInventoryImagePath()

--- a/links/inventories/core_inventory/client.lua
+++ b/links/inventories/core_inventory/client.lua
@@ -9,3 +9,15 @@ end
 function GetPlayerInventory()
     return NormalizeInventoryOutput(exports.core_inventory:getInventory())
 end
+
+local itemsCache
+function GetInventoryItems()
+    if itemsCache then return itemsCache end
+    local items = TriggerServerCallback('kq_link:getInventoryItems') or {}
+    if next(items) then itemsCache = items end
+    return items
+end
+
+function GetInventoryImagePath()
+    return '', 'png'
+end

--- a/links/inventories/core_inventory/server.lua
+++ b/links/inventories/core_inventory/server.lua
@@ -46,4 +46,10 @@ end
 function RemovePlayerWeapon(player, weapon)
     return RemovePlayerItem(player, weapon, 1)
 end
+
+function GetInventoryItems()
+    local ok, raw = pcall(function() return exports.core_inventory:getItemsList() end)
+    if not ok then return {} end
+    return NormalizeItems(raw)
+end
 --

--- a/links/inventories/core_inventory/server.lua
+++ b/links/inventories/core_inventory/server.lua
@@ -48,8 +48,8 @@ function RemovePlayerWeapon(player, weapon)
 end
 
 function GetInventoryItems()
-    local ok, raw = pcall(function() return exports.core_inventory:getItemsList() end)
-    if not ok then return {} end
-    return NormalizeItems(raw)
+    return UseCache('kq_link:core_inventory:items', function()
+        return NormalizeItems(exports.core_inventory:getItemsList())
+    end, 60000)
 end
 --

--- a/links/inventories/jaksam/client.lua
+++ b/links/inventories/jaksam/client.lua
@@ -13,9 +13,7 @@ end
 local itemsCache
 function GetInventoryItems()
     if itemsCache then return itemsCache end
-    local ok, raw = pcall(function() return exports['jaksam_inventory']:getStaticItemsList() end)
-    if not ok then return {} end
-    local items = NormalizeItems(raw)
+    local items = NormalizeItems(exports['jaksam_inventory']:getStaticItemsList())
     if next(items) then itemsCache = items end
     return items
 end

--- a/links/inventories/jaksam/client.lua
+++ b/links/inventories/jaksam/client.lua
@@ -9,3 +9,17 @@ end
 function GetPlayerInventory()
     return NormalizeInventoryOutput(exports['jaksam_inventory']:getInventory())
 end
+
+local itemsCache
+function GetInventoryItems()
+    if itemsCache then return itemsCache end
+    local ok, raw = pcall(function() return exports['jaksam_inventory']:getStaticItemsList() end)
+    if not ok then return {} end
+    local items = NormalizeItems(raw)
+    if next(items) then itemsCache = items end
+    return items
+end
+
+function GetInventoryImagePath()
+    return 'nui://jaksam_inventory/_images/', 'png'
+end

--- a/links/inventories/jaksam/client.lua
+++ b/links/inventories/jaksam/client.lua
@@ -10,12 +10,10 @@ function GetPlayerInventory()
     return NormalizeInventoryOutput(exports['jaksam_inventory']:getInventory())
 end
 
-local itemsCache
 function GetInventoryItems()
-    if itemsCache then return itemsCache end
-    local items = NormalizeItems(exports['jaksam_inventory']:getStaticItemsList())
-    if next(items) then itemsCache = items end
-    return items
+    return UseCache('kq_link:jaksam_inventory:items', function()
+        return NormalizeItems(exports['jaksam_inventory']:getStaticItemsList())
+    end, 60000)
 end
 
 function GetInventoryImagePath()

--- a/links/inventories/origen_inventory/client.lua
+++ b/links/inventories/origen_inventory/client.lua
@@ -10,12 +10,10 @@ function GetPlayerInventory()
     return NormalizeInventoryOutput(exports.origen_inventory:GetInventory())
 end
 
-local itemsCache
 function GetInventoryItems()
-    if itemsCache then return itemsCache end
-    local items = TriggerServerCallback('kq_link:getInventoryItems') or {}
-    if next(items) then itemsCache = items end
-    return items
+    return UseCache('kq_link:origen_inventory:items:client', function()
+        return TriggerServerCallback('kq_link:getInventoryItems') or {}
+    end, 60000)
 end
 
 function GetInventoryImagePath()

--- a/links/inventories/origen_inventory/client.lua
+++ b/links/inventories/origen_inventory/client.lua
@@ -9,3 +9,15 @@ end
 function GetPlayerInventory()
     return NormalizeInventoryOutput(exports.origen_inventory:GetInventory())
 end
+
+local itemsCache
+function GetInventoryItems()
+    if itemsCache then return itemsCache end
+    local items = TriggerServerCallback('kq_link:getInventoryItems') or {}
+    if next(items) then itemsCache = items end
+    return items
+end
+
+function GetInventoryImagePath()
+    return '', 'png'
+end

--- a/links/inventories/origen_inventory/server.lua
+++ b/links/inventories/origen_inventory/server.lua
@@ -65,4 +65,10 @@ end
 function RemovePlayerWeapon(player, weapon)
     return RemovePlayerItem(player, weapon, 1)
 end
+
+function GetInventoryItems()
+    local ok, raw = pcall(function() return exports['origen_inventory']:getItems() end)
+    if not ok then return {} end
+    return NormalizeItems(raw)
+end
 --

--- a/links/inventories/origen_inventory/server.lua
+++ b/links/inventories/origen_inventory/server.lua
@@ -67,8 +67,8 @@ function RemovePlayerWeapon(player, weapon)
 end
 
 function GetInventoryItems()
-    local ok, raw = pcall(function() return exports['origen_inventory']:getItems() end)
-    if not ok then return {} end
-    return NormalizeItems(raw)
+    return UseCache('kq_link:origen_inventory:items', function()
+        return NormalizeItems(exports['origen_inventory']:getItems())
+    end, 60000)
 end
 --

--- a/links/inventories/ox_inventory/client.lua
+++ b/links/inventories/ox_inventory/client.lua
@@ -14,3 +14,17 @@ end
 function GetPlayerInventory()
     return NormalizeInventoryOutput(exports.ox_inventory:GetPlayerItems())
 end
+
+local itemsCache
+function GetInventoryItems()
+    if itemsCache then return itemsCache end
+    local ok, raw = pcall(function() return exports.ox_inventory:Items() end)
+    if not ok then return {} end
+    local items = NormalizeItems(raw)
+    if next(items) then itemsCache = items end
+    return items
+end
+
+function GetInventoryImagePath()
+    return 'nui://ox_inventory/web/images/', 'png'
+end

--- a/links/inventories/ox_inventory/client.lua
+++ b/links/inventories/ox_inventory/client.lua
@@ -18,9 +18,7 @@ end
 local itemsCache
 function GetInventoryItems()
     if itemsCache then return itemsCache end
-    local ok, raw = pcall(function() return exports.ox_inventory:Items() end)
-    if not ok then return {} end
-    local items = NormalizeItems(raw)
+    local items = NormalizeItems(exports.ox_inventory:Items())
     if next(items) then itemsCache = items end
     return items
 end

--- a/links/inventories/ox_inventory/client.lua
+++ b/links/inventories/ox_inventory/client.lua
@@ -15,12 +15,10 @@ function GetPlayerInventory()
     return NormalizeInventoryOutput(exports.ox_inventory:GetPlayerItems())
 end
 
-local itemsCache
 function GetInventoryItems()
-    if itemsCache then return itemsCache end
-    local items = NormalizeItems(exports.ox_inventory:Items())
-    if next(items) then itemsCache = items end
-    return items
+    return UseCache('kq_link:ox_inventory:items', function()
+        return NormalizeItems(exports.ox_inventory:Items())
+    end, 60000)
 end
 
 function GetInventoryImagePath()

--- a/links/inventories/ps-inventory/client.lua
+++ b/links/inventories/ps-inventory/client.lua
@@ -9,3 +9,18 @@ end
 function GetPlayerInventory()
     return NormalizeInventoryOutput(TriggerServerCallback('kq_link:callback:getPlayerInventory'))
 end
+
+local itemsCache
+function GetInventoryItems()
+    if itemsCache then return itemsCache end
+    if not QBCore or not QBCore.Shared or type(QBCore.Shared.Items) ~= 'table' then
+        return {}
+    end
+    local items = NormalizeItems(QBCore.Shared.Items)
+    if next(items) then itemsCache = items end
+    return items
+end
+
+function GetInventoryImagePath()
+    return 'nui://ps-inventory/html/images/', 'png'
+end

--- a/links/inventories/ps-inventory/client.lua
+++ b/links/inventories/ps-inventory/client.lua
@@ -10,15 +10,13 @@ function GetPlayerInventory()
     return NormalizeInventoryOutput(TriggerServerCallback('kq_link:callback:getPlayerInventory'))
 end
 
-local itemsCache
 function GetInventoryItems()
-    if itemsCache then return itemsCache end
-    if not QBCore or not QBCore.Shared or type(QBCore.Shared.Items) ~= 'table' then
-        return {}
-    end
-    local items = NormalizeItems(QBCore.Shared.Items)
-    if next(items) then itemsCache = items end
-    return items
+    return UseCache('kq_link:ps-inventory:items', function()
+        if not QBCore or not QBCore.Shared or type(QBCore.Shared.Items) ~= 'table' then
+            return {}
+        end
+        return NormalizeItems(QBCore.Shared.Items)
+    end, 60000)
 end
 
 function GetInventoryImagePath()

--- a/links/inventories/qs-inventory/client.lua
+++ b/links/inventories/qs-inventory/client.lua
@@ -8,12 +8,10 @@ if Link.inventory ~= 'qs-inventory' and Link.inventory ~= 'qs' then
     return
 end
 
-local itemsCache
 function GetInventoryItems()
-    if itemsCache then return itemsCache end
-    local items = NormalizeItems(exports['qs-inventory']:GetItemList())
-    if next(items) then itemsCache = items end
-    return items
+    return UseCache('kq_link:qs-inventory:items', function()
+        return NormalizeItems(exports['qs-inventory']:GetItemList())
+    end, 60000)
 end
 
 function GetInventoryImagePath()

--- a/links/inventories/qs-inventory/client.lua
+++ b/links/inventories/qs-inventory/client.lua
@@ -3,3 +3,21 @@ AddEventHandler('kq_link:client:qs-inventory:openStash', function(stashId, stash
     TriggerServerEvent('inventory:server:OpenInventory', 'stash', stashId, stashData)
     TriggerEvent("inventory:client:SetCurrentStash", stashId)
 end)
+
+if Link.inventory ~= 'qs-inventory' and Link.inventory ~= 'qs' then
+    return
+end
+
+local itemsCache
+function GetInventoryItems()
+    if itemsCache then return itemsCache end
+    local ok, raw = pcall(function() return exports['qs-inventory']:GetItemList() end)
+    if not ok then return {} end
+    local items = NormalizeItems(raw)
+    if next(items) then itemsCache = items end
+    return items
+end
+
+function GetInventoryImagePath()
+    return 'nui://qs-inventory/html/images/', 'png'
+end

--- a/links/inventories/qs-inventory/client.lua
+++ b/links/inventories/qs-inventory/client.lua
@@ -11,9 +11,7 @@ end
 local itemsCache
 function GetInventoryItems()
     if itemsCache then return itemsCache end
-    local ok, raw = pcall(function() return exports['qs-inventory']:GetItemList() end)
-    if not ok then return {} end
-    local items = NormalizeItems(raw)
+    local items = NormalizeItems(exports['qs-inventory']:GetItemList())
     if next(items) then itemsCache = items end
     return items
 end

--- a/links/inventories/shared.lua
+++ b/links/inventories/shared.lua
@@ -5,9 +5,31 @@ function NormalizeInventoryOutput(inventory_output)
         item.label = item.label or item.name
         item.count = item.count or item.amount
         item.meta = item.meta or item.metadata
-        
+
         normalized_output[pos] = item
     end
 
     return normalized_output
+end
+
+function NormalizeItems(raw)
+    local items = {}
+    if type(raw) ~= 'table' then return items end
+
+    for name, def in pairs(raw) do
+        local key = def.name or name
+        local stack = def.stack
+        if stack == nil then stack = def.unique == nil or def.unique == false end
+
+        items[key] = {
+            name        = key,
+            label       = def.label or def.Label or key,
+            weight      = tonumber(def.weight) or 0,
+            description = def.description or def.desc or '',
+            stack       = stack and true or false,
+            image       = def.image or def.img,
+        }
+    end
+
+    return items
 end

--- a/links/inventories/tgiann-inventory/client.lua
+++ b/links/inventories/tgiann-inventory/client.lua
@@ -18,9 +18,7 @@ end
 local itemsCache
 function GetInventoryItems()
     if itemsCache then return itemsCache end
-    local ok, raw = pcall(function() return exports['tgiann-inventory']:GetItemList() end)
-    if not ok then return {} end
-    local items = NormalizeItems(raw)
+    local items = NormalizeItems(exports['tgiann-inventory']:GetItemList())
     if next(items) then itemsCache = items end
     return items
 end

--- a/links/inventories/tgiann-inventory/client.lua
+++ b/links/inventories/tgiann-inventory/client.lua
@@ -15,12 +15,10 @@ function GetPlayerInventory()
     return NormalizeInventoryOutput(exports["tgiann-inventory"]:Items())
 end
 
-local itemsCache
 function GetInventoryItems()
-    if itemsCache then return itemsCache end
-    local items = NormalizeItems(exports['tgiann-inventory']:GetItemList())
-    if next(items) then itemsCache = items end
-    return items
+    return UseCache('kq_link:tgiann-inventory:items', function()
+        return NormalizeItems(exports['tgiann-inventory']:GetItemList())
+    end, 60000)
 end
 
 function GetInventoryImagePath()

--- a/links/inventories/tgiann-inventory/client.lua
+++ b/links/inventories/tgiann-inventory/client.lua
@@ -14,3 +14,17 @@ end
 function GetPlayerInventory()
     return NormalizeInventoryOutput(exports["tgiann-inventory"]:Items())
 end
+
+local itemsCache
+function GetInventoryItems()
+    if itemsCache then return itemsCache end
+    local ok, raw = pcall(function() return exports['tgiann-inventory']:GetItemList() end)
+    if not ok then return {} end
+    local items = NormalizeItems(raw)
+    if next(items) then itemsCache = items end
+    return items
+end
+
+function GetInventoryImagePath()
+    return 'nui://tgiann-inventory/inventory_images/images/', 'webp'
+end


### PR DESCRIPTION
## Summary
Adds `GetInventoryItems()` and `GetInventoryImagePath()` client-side exports.

- `GetInventoryItems()` — returns `{[name] = {name, label, weight, description, stack, image}}`
- `GetInventoryImagePath()` — returns `(path, format)`, e.g. `('nui://ox_inventory/web/images/', 'png')`

## Native client call
ox_inventory, ak47_inventory, qs-inventory, codem-inventory, tgiann-inventory, ps-inventory, jaksam, qb-inventory/QBCore

## Server callback fallback (`kq_link:getInventoryItems`)
Item catalog is server-only for these:
- core_inventory
- origen_inventory
- chezza
- ESX framework-inventory

## Image path not verified (empty string)
- ak47_inventory
- core_inventory
- origen_inventory

Also adds 6 missing inventory client files to fxmanifest so `GetPlayerInventory` / `GetItemCount` load for them.